### PR TITLE
Return an ok status on no advisories

### DIFF
--- a/src/SecurityAdvisoriesCheck.php
+++ b/src/SecurityAdvisoriesCheck.php
@@ -22,7 +22,7 @@ class SecurityAdvisoriesCheck extends Check
         $advisories = $this->getAdvisories($packages);
 
         if ($advisories->isEmpty()) {
-            return Result::make('No security vulnerability advisories found');
+            return Result::make('No security vulnerability advisories found')->ok();
         }
 
         $packageNames = $advisories->keys()


### PR DESCRIPTION
This ensures that emails don't get sent when the health check is perfectly fine