### PR TITLE
Decrease the minimum support version and add support for PHP 8.2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,10 +4,11 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
       matrix:
+        os: [ubuntu-latest]
         php: [8.0, 8.1, 8.2]
         laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,10 @@
 name: run-tests
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,11 +13,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1]
+        php: [8.0, 8.1, 8.2]
         laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
+            php: ^8.0.2
             testbench: ^7.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,24 +1,18 @@
 name: run-tests
 
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+on: [push]
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
         php: [8.0, 8.1, 8.2]
         laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
-            php: ^8.0.2
             testbench: ^7.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          extensions: mbstring
           coverage: none
 
       - name: Setup problem matchers

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "^8.0",
         "spatie/packagist-api": "^2.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.0.2",
         "spatie/packagist-api": "^2.1"
     },
     "require-dev": {


### PR DESCRIPTION
Hello,

I would like to propose to decrease the minimum supported version of the package.
The current version 8.1 doesn't agree with the [PHP version](https://github.com/spatie/laravel-health/blob/97cbfa4f9531c5bc24f76c99f203e58f7d1a4b76/composer.json#L19) of the main package.

PS: Same PR adds support for PHP 8.2.