### PR TITLE
Handle intermittent failures caused by unreliable packagist api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     },
     "require-dev": {
         "nunomaduro/collision": "^6.0",
+        "orchestra/testbench": "^8.5",
         "pestphp/pest": "^1.21.1",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^8.0",
+        "hammerstone/flaky": "^0.1.5",
         "spatie/packagist-api": "^2.1"
     },
     "require-dev": {

--- a/src/SecurityAdvisoriesCheck.php
+++ b/src/SecurityAdvisoriesCheck.php
@@ -69,7 +69,7 @@ class SecurityAdvisoriesCheck extends Check
      */
     protected function getAdvisories(Collection $packages): Collection
     {
-        $advisories = Flaky::make('health-check-retrieve-packagist-advisories')
+        $result = Flaky::make('health-check-retrieve-packagist-advisories')
             ->allowFailuresForAnHour()
             ->run(function() use ($packages) {
                 return $this
@@ -77,7 +77,7 @@ class SecurityAdvisoriesCheck extends Check
                     ->getAdvisoriesAffectingVersions($packages->toArray());
             });
 
-        return collect($advisories);
+        return collect($result->value);
     }
 
     protected function getPackagist(): PackagistClient

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,1 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
+use Spatie\SecurityAdvisoriesHealthCheck\Tests\TestCase;
+
+uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\SecurityAdvisoriesHealthCheck\Tests;
+
+use Orchestra\Testbench\TestCase as Orchestra;
+
+class TestCase extends Orchestra
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+    }
+}


### PR DESCRIPTION
prevent check to alert with false positive when packagist api responds intermitently with https://github.com/hammerstonedev/flaky

see https://github.com/spatie/security-advisories-health-check/discussions/13