### PR TITLE
Retry Packagist API 

### DIFF
--- a/src/SecurityAdvisoriesCheck.php
+++ b/src/SecurityAdvisoriesCheck.php
@@ -85,12 +85,12 @@ class SecurityAdvisoriesCheck extends Check
                 break;
             } catch (Exception $e) {
                 if ($attempts === $maxAttempts) {
-                    throw $e;
+                    break;
                 }
 
                 usleep(100_000);
             }
-        } while ($attempts <= $maxAttempts);
+        } while ($attempts < $maxAttempts);
 
         return collect($advisories);
     }


### PR DESCRIPTION
Fixes the same issue as #14.

It retries the Packagist API five times and returns an empty array if the API fails each time. That way the check will be green with no advisories.

This uses a clunky do-while loop but it seems better then requiring a new library or guzzle middleware for retries.

I assume #14 fails because of the new dependencies.