### PR TITLE
Ignore Packagist connection errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ use Spatie\Health\Facades\Health;
 use Spatie\SecurityAdvisoriesHealthCheck\SecurityAdvisoriesCheck;
 
 Health::checks([
-    SecurityAdvisoriesCheck::new(),
+    SecurityAdvisoriesCheck::new()->retryTimes(5),
 ]);
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5.10|^10.5",
-        "spatie/laravel-health": "^1.12.2"
+        "spatie/laravel-health": "^1.22.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/SecurityAdvisoriesCheck.php
+++ b/src/SecurityAdvisoriesCheck.php
@@ -72,7 +72,7 @@ class SecurityAdvisoriesCheck extends Check
 
         $packageNames = $advisories->keys()
             ->map(fn (string $packageName) => "`{$packageName}`")
-            ->join(", ", ' and ');
+            ->join(', ', ' and ');
 
         return Result::make()
             ->meta($advisories->toArray())

--- a/tests/SecurityAdvisoriesCheckTest.php
+++ b/tests/SecurityAdvisoriesCheckTest.php
@@ -43,12 +43,12 @@ it('returns ok status if 502, 503, or 504 is returned all 5 times', function () 
     expect($result->status)->toBe(Status::ok());
 });
 
-it('should throw the last encountered non-gateway error after retrying gateway errors', function () {
+it('should throw the last encountered non-gateway exception after retrying gateway and non-gateway exceptions', function () {
     $mock = new MockHandler([
         new Response(502),
-        new Response(503),
+        new Response(400),
         new Response(504),
-        new Response(400), // Non-retryable error not related to gateway issues
+        new Response(403),
         new Response(504),
     ]);
     $handlerStack = HandlerStack::create($mock);
@@ -58,4 +58,4 @@ it('should throw the last encountered non-gateway error after retrying gateway e
     $check = new SecurityAdvisoriesCheck($packagistClient);
 
     $check->run();
-})->throws(ClientException::class);
+})->throws(ClientException::class, null, 403);

--- a/tests/SecurityAdvisoriesCheckTest.php
+++ b/tests/SecurityAdvisoriesCheckTest.php
@@ -1,7 +1,13 @@
 <?php
 
+use GuzzleHttp\Exception\ClientException;
 use Spatie\Health\Enums\Status;
 use Spatie\SecurityAdvisoriesHealthCheck\SecurityAdvisoriesCheck;
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Spatie\Packagist\PackagistClient;
 
 it('can get security advisories', function () {
     $check = new SecurityAdvisoriesCheck();
@@ -16,3 +22,36 @@ it('can get security advisories', function () {
 
     expect(count($result->meta))->toBeGreaterThan(0);
 });
+
+
+it('returns ok status if 502, 503, or 504 is returned all 5 times', function () {
+    $mock = new MockHandler([
+        new Response(502), new Response(503), new Response(504), new Response(502), new Response(503)
+    ]);
+    $handlerStack = HandlerStack::create($mock);
+    $client = new Client(['handler' => $handlerStack]);
+
+    $packagistClient = new PackagistClient($client, new Spatie\Packagist\PackagistUrlGenerator());
+    $check = new SecurityAdvisoriesCheck($packagistClient);
+
+    $result = $check->run();
+
+    expect($result->status)->toBe(Status::ok());
+});
+
+it('should throw the last encountered non-gateway error after retrying gateway errors', function () {
+    $mock = new MockHandler([
+        new Response(502),
+        new Response(503),
+        new Response(504),
+        new Response(400), // Non-retryable error not related to gateway issues
+        new Response(504)
+    ]);
+    $handlerStack = HandlerStack::create($mock);
+    $client = new Client(['handler' => $handlerStack]);
+
+    $packagistClient = new PackagistClient($client, new Spatie\Packagist\PackagistUrlGenerator());
+    $check = new SecurityAdvisoriesCheck($packagistClient);
+
+    $check->run();
+})->throws(ClientException::class);

--- a/tests/SecurityAdvisoriesCheckTest.php
+++ b/tests/SecurityAdvisoriesCheckTest.php
@@ -1,13 +1,13 @@
 <?php
 
-use GuzzleHttp\Exception\ClientException;
-use Spatie\Health\Enums\Status;
-use Spatie\SecurityAdvisoriesHealthCheck\SecurityAdvisoriesCheck;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use Spatie\Health\Enums\Status;
 use Spatie\Packagist\PackagistClient;
+use Spatie\SecurityAdvisoriesHealthCheck\SecurityAdvisoriesCheck;
 
 it('can get security advisories', function () {
     $check = new SecurityAdvisoriesCheck();
@@ -23,11 +23,15 @@ it('can get security advisories', function () {
     expect(count($result->meta))->toBeGreaterThan(0);
 });
 
-
 it('returns ok status if 502, 503, or 504 is returned all 5 times', function () {
     $mock = new MockHandler([
-        new Response(502), new Response(503), new Response(504), new Response(502), new Response(503)
+        new Response(502),
+        new Response(503),
+        new Response(504),
+        new Response(502),
+        new Response(503),
     ]);
+
     $handlerStack = HandlerStack::create($mock);
     $client = new Client(['handler' => $handlerStack]);
 
@@ -45,7 +49,7 @@ it('should throw the last encountered non-gateway error after retrying gateway e
         new Response(503),
         new Response(504),
         new Response(400), // Non-retryable error not related to gateway issues
-        new Response(504)
+        new Response(504),
     ]);
     $handlerStack = HandlerStack::create($mock);
     $client = new Client(['handler' => $handlerStack]);


### PR DESCRIPTION
This PR prevents Packagist connection errors from being mistakenly reported as security issues during health checks.

**Changes**:

1. **Handling Connection Errors**: Updated the check to return an "ok" status when all retries are due to Packagist connection problems (502, 503, or 504 errors).

2. **Handling Other Errors**: Ensure that errors not related to Packagist connection (like a 400 error) are thrown after all retries. Check out the _"should throw the last encountered non-gateway error after retrying gateway errors"_ unit test to see why this is needed.

3. **Easier Testing**: Moved the creation of `PackagistClient` to the constructor, which makes it easier to set up tests.

4. **Unit Tests**: Added more tests to cover the new error-handling logic.

**Other Changes**:

1. **Configurable Retry Attempts**: Added `retryTimes(int $times)` to let users set how many times they want to retry.

**Files Modified**:
- `SecurityAdvisoriesCheck.php`
- `SecurityAdvisoriesCheckTest.php`
- `README.md`