### PR TITLE
Allow opt-in caching of the security check

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,59 @@ Health::checks([
 ]);
 ```
 
+## Caching
+
+By default, this package will make an HTTP request to Packagist every time the health check runs. To reduce API calls and improve performance, you can enable caching by calling `cacheExpiryInMinutes()`:
+
+```php
+use Spatie\Health\Facades\Health;
+use Spatie\SecurityAdvisoriesHealthCheck\SecurityAdvisoriesCheck;
+
+Health::checks([
+    SecurityAdvisoriesCheck::new()
+        ->retryTimes(5)
+        ->cacheExpiryInMinutes(60), // Enables caching for 1 hour
+]);
+```
+
+### Using Custom Cache
+
+You can also provide your own PSR-16 compatible cache instance:
+
+```php
+use Illuminate\Support\Facades\Cache;
+use Spatie\Health\Facades\Health;
+use Spatie\SecurityAdvisoriesHealthCheck\SecurityAdvisoriesCheck;
+
+Health::checks([
+    SecurityAdvisoriesCheck::new(
+        packagistClient: null,
+        cache: Cache::store('redis') // Use Redis cache store
+    )->cacheExpiryInMinutes(120), // Cache for 2 hours
+]);
+```
+
+### Cache Behavior
+
+- **Cache Key**: Automatically generated based on your installed packages and their versions
+- **Cache Duration**: Configurable via `cacheExpiryInMinutes()` method (default: 60 minutes)
+- **Cache Store**: Uses Laravel's default cache driver, or you can specify a custom cache instance
+- **Cache Invalidation**: Cache automatically expires after the configured duration
+- **Package Changes**: Different package lists generate different cache keys, ensuring accuracy
+
+### Configuration Options
+
+```php
+SecurityAdvisoriesCheck::new()
+    ->retryTimes(3)                    // Number of retry attempts on failure
+    ->cacheExpiryInMinutes(120)        // Cache duration in minutes
+    ->ignorePackage('vendor/package')  // Ignore specific packages
+    ->ignoredPackages([               // Ignore multiple packages
+        'vendor/package1',
+        'vendor/package2'
+    ]);
+```
+
 ## Documentation
 
 The documentation of this package is available [inside the docs of Laravel Health](https://spatie.be/docs/laravel-health/v1/available-checks/security-advisories).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ use Spatie\SecurityAdvisoriesHealthCheck\SecurityAdvisoriesCheck;
 Health::checks([
     SecurityAdvisoriesCheck::new()
         ->retryTimes(5)
-        ->cacheExpiryInMinutes(60), // Enables caching for 1 hour
+        ->cacheExpiryInMinutes(60),     // Enables caching for 1 hour
 ]);
 ```
 
@@ -45,27 +45,26 @@ use Spatie\SecurityAdvisoriesHealthCheck\SecurityAdvisoriesCheck;
 Health::checks([
     SecurityAdvisoriesCheck::new(
         packagistClient: null,
-        cache: Cache::store('redis') // Use Redis cache store
-    )->cacheExpiryInMinutes(120), // Cache for 2 hours
+        cache: Cache::store('redis')    // Use Redis cache store
+    )->cacheExpiryInMinutes(120),       // Cache for 2 hours
 ]);
 ```
 
 ### Cache Behavior
 
 - **Cache Key**: Automatically generated based on your installed packages and their versions
-- **Cache Duration**: Configurable via `cacheExpiryInMinutes()` method (default: 60 minutes)
+- **Cache Duration**: Configurable via `cacheExpiryInMinutes()` method (default: 0, no caching)
 - **Cache Store**: Uses Laravel's default cache driver, or you can specify a custom cache instance
-- **Cache Invalidation**: Cache automatically expires after the configured duration
-- **Package Changes**: Different package lists generate different cache keys, ensuring accuracy
+- **Package Changes**: Different package lists generate different cache keys, refreshing the cache
 
 ### Configuration Options
 
 ```php
 SecurityAdvisoriesCheck::new()
-    ->retryTimes(3)                    // Number of retry attempts on failure
-    ->cacheExpiryInMinutes(120)        // Cache duration in minutes
-    ->ignorePackage('vendor/package')  // Ignore specific packages
-    ->ignoredPackages([               // Ignore multiple packages
+    ->retryTimes(3)                     // Number of retry attempts on failure
+    ->cacheExpiryInMinutes(120)         // Cache duration in minutes
+    ->ignorePackage('vendor/package')   // Ignore specific packages
+    ->ignoredPackages([                 // Ignore multiple packages
         'vendor/package1',
         'vendor/package2'
     ]);

--- a/src/SecurityAdvisoriesCheck.php
+++ b/src/SecurityAdvisoriesCheck.php
@@ -6,6 +6,8 @@ use Composer\InstalledVersions;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ServerException;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Psr\SimpleCache\CacheInterface;
 use Spatie\Health\Checks\Check;
 use Spatie\Health\Checks\Result;
 use Spatie\Packagist\PackagistClient;
@@ -25,17 +27,44 @@ class SecurityAdvisoriesCheck extends Check
 
     public PackagistClient $packagistClient;
 
-    public function __construct(?PackagistClient $packagistClient = null)
+    protected int $cacheExpiryInMinutes = 60;
+
+    protected ?CacheInterface $cache = null;
+
+    public function __construct(?PackagistClient $packagistClient = null, ?CacheInterface $cache = null)
     {
         parent::__construct();
 
         $this->packagistClient = $packagistClient
             ?? new PackagistClient(new Client(), new PackagistUrlGenerator());
+
+        $this->cache = $cache;
+    }
+
+    protected function getDefaultCache(): ?CacheInterface
+    {
+        if (function_exists('app') && app()->bound('cache')) {
+            return Cache::store();
+        }
+
+        return null;
     }
 
     public function retryTimes(int $times): self
     {
         $this->retryTimes = $times;
+
+        return $this;
+    }
+
+    public function cacheExpiryInMinutes(int $minutes): self
+    {
+        $this->cacheExpiryInMinutes = $minutes;
+
+        // If no cache was provided, set up the default cache when caching is explicitly requested
+        if ($this->cache === null) {
+            $this->cache = $this->getDefaultCache();
+        }
 
         return $this;
     }
@@ -104,11 +133,40 @@ class SecurityAdvisoriesCheck extends Check
      */
     protected function getAdvisories(Collection $packages): Collection
     {
+        if ($this->cache === null) {
+            return $this->fetchAdvisoriesFromApi($packages);
+        }
+
+        $cacheKey = $this->getCacheKey($packages);
+
+        $cached = $this->cache->get($cacheKey);
+        if ($cached !== null) {
+            return collect($cached);
+        }
+
+        $advisories = $this->fetchAdvisoriesFromApi($packages);
+        $this->cache->set($cacheKey, $advisories->toArray(), $this->cacheExpiryInMinutes * 60);
+
+        return $advisories;
+    }
+
+    protected function fetchAdvisoriesFromApi(Collection $packages): Collection
+    {
         $advisories = $this
             ->packagistClient
             ->getAdvisoriesAffectingVersions($packages->toArray());
 
         return collect($advisories);
+    }
+
+    protected function getCacheKey(Collection $packages): string
+    {
+        return 'security-advisories:' . md5(
+            $packages
+                ->sortKeys()
+                ->map(fn ($version, $name) => "{$name}:{$version}")
+                ->implode('|')
+        );
     }
 
     protected function allRetriesAreGatewayErrors(): bool

--- a/src/SecurityAdvisoriesCheck.php
+++ b/src/SecurityAdvisoriesCheck.php
@@ -27,7 +27,7 @@ class SecurityAdvisoriesCheck extends Check
 
     public PackagistClient $packagistClient;
 
-    protected int $cacheExpiryInMinutes = 60;
+    protected int $cacheExpiryInMinutes = 0;
 
     protected ?CacheInterface $cache = null;
 
@@ -62,7 +62,7 @@ class SecurityAdvisoriesCheck extends Check
         $this->cacheExpiryInMinutes = $minutes;
 
         // If no cache was provided, set up the default cache when caching is explicitly requested
-        if ($this->cache === null) {
+        if ($this->cache === null && $minutes > 0) {
             $this->cache = $this->getDefaultCache();
         }
 

--- a/tests/SecurityAdvisoriesCheckTest.php
+++ b/tests/SecurityAdvisoriesCheckTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Psr7\Response;
 use Spatie\Health\Enums\Status;
 use Spatie\Packagist\PackagistClient;
 use Spatie\SecurityAdvisoriesHealthCheck\SecurityAdvisoriesCheck;
+use Spatie\SecurityAdvisoriesHealthCheck\Tests\TestCache;
 
 it('can get security advisories', function () {
     $check = new SecurityAdvisoriesCheck();
@@ -59,3 +60,132 @@ it('should throw the last encountered non-gateway exception after retrying gatew
 
     $check->run();
 })->throws(ClientException::class, null, 403);
+
+it('caches security advisories results', function () {
+    $cache = new TestCache();
+
+    $mockData = json_encode([
+        'advisories' => [
+            'vendor/package' => [
+                [
+                    'advisoryId' => 'ADVISORY-123',
+                    'affectedVersions' => '>=1.0,<1.1',
+                    'title' => 'Test Security Issue'
+                ]
+            ]
+        ]
+    ]);
+
+    $mock = new MockHandler([
+        new Response(200, [], $mockData),
+    ]);
+
+    $handlerStack = HandlerStack::create($mock);
+    $client = new Client(['handler' => $handlerStack]);
+
+    $packagistClient = new PackagistClient($client, new Spatie\Packagist\PackagistUrlGenerator());
+    $check = new SecurityAdvisoriesCheck($packagistClient, $cache);
+
+    // First call should hit the API
+    $result1 = $check->run();
+
+    // Mock should be empty now, but second call should use cache
+    $mock->append(new Response(500)); // This should not be called due to caching
+
+    $result2 = $check->run();
+
+    expect($result1->status)->toBe($result2->status);
+    expect($result1->notificationMessage)->toBe($result2->notificationMessage);
+});
+
+it('respects custom cache expiry time', function () {
+    $cache = new TestCache();
+
+    $mockData = json_encode([
+        'advisories' => [
+            'vendor/package' => [
+                [
+                    'advisoryId' => 'ADVISORY-456',
+                    'affectedVersions' => '>=2.0,<2.1',
+                    'title' => 'Another Security Issue'
+                ]
+            ]
+        ]
+    ]);
+
+    $mock = new MockHandler([
+        new Response(200, [], $mockData),
+    ]);
+
+    $handlerStack = HandlerStack::create($mock);
+    $client = new Client(['handler' => $handlerStack]);
+
+    $packagistClient = new PackagistClient($client, new Spatie\Packagist\PackagistUrlGenerator());
+    $check = new SecurityAdvisoriesCheck($packagistClient, $cache);
+    $check->cacheExpiryInMinutes(120); // 2 hours
+
+    $result = $check->run();
+
+    // Verify that something was cached (we can't easily check the exact key without exposing it)
+    expect($result)->toBeInstanceOf(\Spatie\Health\Checks\Result::class);
+});
+
+it('cache key changes when package list changes', function () {
+    $cache1 = new TestCache();
+    $cache2 = new TestCache();
+
+    $mockData1 = json_encode(['advisories' => []]);
+    $mockData2 = json_encode(['advisories' => []]);
+
+    $mock = new MockHandler([
+        new Response(200, [], $mockData1),
+        new Response(200, [], $mockData2),
+    ]);
+
+    $handlerStack = HandlerStack::create($mock);
+    $client = new Client(['handler' => $handlerStack]);
+
+    $packagistClient = new PackagistClient($client, new Spatie\Packagist\PackagistUrlGenerator());
+
+    // Create two different check instances with different ignored packages and different caches
+    $check1 = new SecurityAdvisoriesCheck($packagistClient, $cache1);
+    $check1->ignorePackage('some/package');
+
+    $check2 = new SecurityAdvisoriesCheck($packagistClient, $cache2);
+    $check2->ignorePackage('different/package');
+
+    // Both should make HTTP calls since they have different cache keys
+    $result1 = $check1->run();
+    $result2 = $check2->run();
+
+    expect($result1->status)->toBe(Status::ok());
+    expect($result2->status)->toBe(Status::ok());
+    expect($mock->count())->toBe(0); // Both requests should have been made
+});
+
+it('prevents external API calls when cache is hit', function () {
+    $cache = new TestCache();
+
+    $mockData = json_encode(['advisories' => []]);
+
+    $mock = new MockHandler([
+        new Response(200, [], $mockData),
+        // No second response - if the second call tries to hit the API, it will fail
+    ]);
+
+    $handlerStack = HandlerStack::create($mock);
+    $client = new Client(['handler' => $handlerStack]);
+
+    $packagistClient = new PackagistClient($client, new Spatie\Packagist\PackagistUrlGenerator());
+    $check = new SecurityAdvisoriesCheck($packagistClient, $cache);
+
+    // First call should hit the API and populate cache
+    $result1 = $check->run();
+    expect($result1->status)->toBe(Status::ok());
+    expect($mock->count())->toBe(0); // One request consumed
+
+    // Second call should use cache, not hit API
+    $result2 = $check->run();
+    expect($result2->status)->toBe(Status::ok());
+    expect($mock->count())->toBe(0); // No additional requests consumed
+});

--- a/tests/TestCache.php
+++ b/tests/TestCache.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Spatie\SecurityAdvisoriesHealthCheck\Tests;
+
+use Psr\SimpleCache\CacheInterface;
+
+class TestCache implements CacheInterface
+{
+    private array $cache = [];
+    private array $expiry = [];
+
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $this->checkExpiry($key);
+
+        return $this->cache[$key] ?? $default;
+    }
+
+    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
+    {
+        $this->cache[$key] = $value;
+
+        if ($ttl !== null) {
+            $expiryTime = is_int($ttl)
+                ? time() + $ttl
+                : time() + $ttl->totalSeconds;
+            $this->expiry[$key] = $expiryTime;
+        }
+
+        return true;
+    }
+
+    public function delete(string $key): bool
+    {
+        unset($this->cache[$key], $this->expiry[$key]);
+
+        return true;
+    }
+
+    public function clear(): bool
+    {
+        $this->cache = [];
+        $this->expiry = [];
+
+        return true;
+    }
+
+    public function getMultiple(iterable $keys, mixed $default = null): iterable
+    {
+        $result = [];
+        foreach ($keys as $key) {
+            $result[$key] = $this->get($key, $default);
+        }
+
+        return $result;
+    }
+
+    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
+    {
+        foreach ($values as $key => $value) {
+            $this->set($key, $value, $ttl);
+        }
+
+        return true;
+    }
+
+    public function deleteMultiple(iterable $keys): bool
+    {
+        foreach ($keys as $key) {
+            $this->delete($key);
+        }
+
+        return true;
+    }
+
+    public function has(string $key): bool
+    {
+        $this->checkExpiry($key);
+
+        return array_key_exists($key, $this->cache);
+    }
+
+    private function checkExpiry(string $key): void
+    {
+        if (isset($this->expiry[$key]) && time() > $this->expiry[$key]) {
+            unset($this->cache[$key], $this->expiry[$key]);
+        }
+    }
+}


### PR DESCRIPTION
This avoids 429 Rate Limit errors on Packagist from frequent requests by optionally caching the results instead of live-fetching on every application-health invokation

```
 The check named `SecurityAdvisories` did not complete. An exception was thrown with this message: `GuzzleHttp\Exception\ClientException: Client error: `POST https://packagist.org/api/security-advisories/` resulted in a `429 Too Many Requests` response:
"Please use a proper user agent with contact information to use our API"
` {"exception":"[object] (Spatie\\Health\\Exceptions\\CheckDidNotComplete(code: 0): The check named `SecurityAdvisories` did not complete. An exception was thrown with this message: `GuzzleHttp\\Exception\\ClientException: Client error: `POST https://packagist.org/api/security-advisories/` resulted in a `429 Too Many Requests` response:
\"Please use a proper user agent with contact information to use our API\"
` at vendor/spatie/laravel-health/src/Exceptions/CheckDidNotComplete.php:12)
```